### PR TITLE
Add new command line argument --private

### DIFF
--- a/kicost/__main__.py
+++ b/kicost/__main__.py
@@ -63,6 +63,12 @@ def main():
     parser.add_argument('-s', '--serial',
                         action='store_true',
                         help='Do web scraping of part data using a single process.')
+    parser.add_argument('-p', '--private',
+                        nargs='+',
+                        default=[],
+                        help='Declare a field private, to be ignored when grouping objects',
+                        metavar='field',
+                        type=str)
     parser.add_argument(
         '-d', '--debug',
         nargs='?',
@@ -100,7 +106,7 @@ def main():
         logger.addHandler(handler)
         logger.setLevel(log_level)
 
-    kicost(in_file=args.input, out_filename=args.output, serial=args.serial)
+    kicost(in_file=args.input, out_filename=args.output, serial=args.serial, private=args.private)
 
     
 ###############################################################################


### PR DESCRIPTION
Sometimes there are fields related to components which do not ruin one component being equivalent to another. A comment field detailing layout suggestions etc for a specific instance would be one example, or fields leftover from previous attempts at BOM management, which still contain useful data (my personal need) another. However, having such fields makes kicost's component grouping next to useless.

Solution: add new command line argument. The argument -p or --private allows defining fields as private in the sense that they do not affect the grouping of components, even if they differ between component instances.

The argument name may not be optimal, but the abbreviation -i for --ignore would have clashed with --input

N.B. I'm breaking the suggested guidelines for pull requests with regards to unit tests, since I don't see any tests implemented in the current main branch anyway. Sorry for validating the broken windows theory :) I've tested the addition in Python 3.4 on OS X, and also that it doesn't break existing functionality.

I'll be happy to add explanation on the feature to the documentation, if the request gets approved.
