### PR TITLE
Add -f "fitting" option.  Allows different BOMS per board

### DIFF
--- a/kicost/__main__.py
+++ b/kicost/__main__.py
@@ -1,17 +1,17 @@
 # MIT license
-# 
+#
 # Copyright (C) 2015 by XESS Corporation
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,6 +57,10 @@ def main():
                         type=str,
                         metavar='file.xlsx',
                         help='Generated cost spreadsheet.')
+    parser.add_argument('-f', '--fitting',
+                        nargs='?',
+                        type=str,
+                        help='fitting option name')
     parser.add_argument('-w', '--overwrite',
                         action='store_true',
                         help='Allow overwriting of an existing spreadsheet.')
@@ -100,9 +104,9 @@ def main():
         logger.addHandler(handler)
         logger.setLevel(log_level)
 
-    kicost(in_file=args.input, out_filename=args.output, serial=args.serial)
+    kicost(in_file=args.input, out_filename=args.output, serial=args.serial, fitting=args.fitting)
 
-    
+
 ###############################################################################
 # Main entrypoint.
 ###############################################################################


### PR DESCRIPTION
This patch allows for a new options called "fitting" to be passed when processing the BOM.

The purpose of it is so that a single design can have multiple BOMs defined, based on a named "fitting" which chooses optional/alternate components.

It extends the namespace:

So for example:
KiCost:manf# is the generic item fitted to all boards, but
KiCost.<fitting>:manf# is the manf# ONLY for the specified fitting option.

To have KiCost reference the fitting the new -f option has been added, where you specify the name of the fitting option to generate a BOM form.

eg:
kicost -i file.xml -o file.xlsx -f RF433

Now components with "KiCost.RF433:manf#" defined will be looked up but "KiCost.RF915:manf#" will be ignored.

To make it plain which fitting option the BOM was generated for, the fitting is added to the tab name.

The fitting option name is case insensitive.
