### PR TITLE
Catch BeautifulSoup exception when parsing

### DIFF
--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -1547,7 +1547,10 @@ def get_digikey_part_html_tree(dist, pn, extra_search_terms='', url=None, descen
     # except Exception as e:
     # print('Exception reading with Ghost: {}'.format(e))
 
-    tree = BeautifulSoup(html, 'lxml')
+    try:
+        tree = BeautifulSoup(html, 'lxml')
+    except:
+        raise PartHtmlError
 
     # If the tree contains the tag for a product page, then return it.
     if tree.find('div', class_='product-top-section') is not None:
@@ -1666,7 +1669,10 @@ def get_mouser_part_html_tree(dist, pn, extra_search_terms='', url=None, descend
             pass
     else: # Couldn't get a good read from the website.
         raise PartHtmlError
-    tree = BeautifulSoup(html, 'lxml')
+    try:
+        tree = BeautifulSoup(html, 'lxml')
+    except:
+       raise PartHtmlError
 
     # If the tree contains the tag for a product page, then just return it.
     if tree.find('div', id='product-details') is not None:
@@ -1729,7 +1735,10 @@ def get_newark_part_html_tree(dist, pn, extra_search_terms='', url=None, descend
             pass
     else: # Couldn't get a good read from the website.
         raise PartHtmlError
-    tree = BeautifulSoup(html, 'lxml')
+    try:
+        tree = BeautifulSoup(html, 'lxml')
+    except:
+        raise PartHtmlError
 
     # If the tree contains the tag for a product page, then just return it.
     if tree.find('div', class_='productDisplay', id='page') is not None:


### PR DESCRIPTION
It looks the HTML pages returned by Mouser and Newark are
not compliant when requested components do not exist in these
distributor databases.

This change prevent KiCost to crash and to pursue its processing.

It should fix https://github.com/xesscorp/KiCost/issues/45.
