### PR TITLE
Multipart components (issue #34) & Spreadsheetorder (issue #84)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -120,7 +120,7 @@ That can be prevented in two ways:
 Multiple Parts
 ------------------------
 
-KiCost allow use of multiple parts with diferent quantities to one designator, an userfull resource to list parts to assembly conectors and so on. To use, the subparts have to be separeted by comma or semicolon and the quantity (optional, default is 1) separeted by ":".
+KiCost (not Altium yet) allow use of multiple parts with diferent quantities to one designator, an userfull resource to list parts to assembly conectors and so on. To use, the subparts have to be separeted by comma or semicolon and the quantity (optional, default is 1) separeted by ":".
 
 E.g., em maf# field of KiCad:
 
@@ -249,8 +249,10 @@ Command-Line Options
                             Declare part fields to ignore when grouping parts.
       -d [LEVEL], --debug [LEVEL]
                             Print debugging info. (Larger LEVEL means more info.)
-      -a, --altium          Allows parsing of an Altium Designer .xml BOM file
-                            specified as input.
+      --eda_tool ['kicad', 'altium', ...]
+                            Allows parsing of an Altium Designer .xml BOM file
+                            specified as input (or other sub module in 'eda_tools'
+                            folder) instead of KiCad.
       -e dist [dist ...], --exclude dist [dist ...]
                             Excludes the given distributor(s) from the scraping
                             process.

--- a/kicost/eda_tools/altium/altium.py
+++ b/kicost/eda_tools/altium/altium.py
@@ -129,9 +129,6 @@ def get_part_groups_altium(in_file, ignore_fields, variant):
 
     prj_info = {'title':'test_title','company':'test_company'} # Not implemented yet.
 
-    # Sort the founded groups by BOM_ORDER definition.
-    new_component_groups = groups_sort(new_component_groups)
-
     # Now return the list of identical part groups.
     return new_component_groups, prj_info
 

--- a/kicost/eda_tools/eda_tools.py
+++ b/kicost/eda_tools/eda_tools.py
@@ -75,9 +75,7 @@ def groups_sort(new_component_groups):
                 # Examine 'manf#' to get the order.
                 group_manf_list = [new_component_groups[h].fields.get('manf#') for h in component_groups_ref_match]
                 if group_manf_list:
-                    m=group_manf_list
                     sorted_groups = sorted(range(len(group_manf_list)), key=lambda k:(group_manf_list[k] is None,  group_manf_list[k]))
-#                    [i[0] for i in sorted(enumerate(group_manf_list), key=lambda x:x[1])]
                     if logger.isEnabledFor(DEBUG_OBSESSIVE):
                         print(group_manf_list,' > order: ', sorted_groups)
                     component_groups_ref_match = [component_groups_ref_match[i] for i in sorted_groups]

--- a/kicost/eda_tools/eda_tools.py
+++ b/kicost/eda_tools/eda_tools.py
@@ -72,13 +72,14 @@ def groups_sort(new_component_groups):
                         component_groups_order_old.remove(item)
                 except ValueError:
                     pass
-                # Examine 'manf#' to get the order.
+                # Examine 'manf#' and refs to get the order.
+                # Order by refs that have 'manf#' codes, that ones that don't have stay at the end of the group.
                 group_manf_list = [new_component_groups[h].fields.get('manf#') for h in component_groups_ref_match]
-                if group_manf_list:
-                    sorted_groups = sorted(range(len(group_manf_list)), key=lambda k:(group_manf_list[k] is None,  group_manf_list[k]))
-                    if logger.isEnabledFor(DEBUG_OBSESSIVE):
-                        print(group_manf_list,' > order: ', sorted_groups)
-                    component_groups_ref_match = [component_groups_ref_match[i] for i in sorted_groups]
+                group_refs_list = [new_component_groups[h].refs for h in component_groups_ref_match]
+                sorted_groups = sorted(range(len(group_refs_list)), key=lambda k:(group_manf_list[k] is None,  group_refs_list[k]))
+                if logger.isEnabledFor(DEBUG_OBSESSIVE):
+                    print(group_manf_list,' > order: ', sorted_groups)
+                component_groups_ref_match = [component_groups_ref_match[i] for i in sorted_groups]
                 component_groups_order_new += component_groups_ref_match
             else:
                 try:

--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -475,9 +475,6 @@ def get_part_groups(in_file, ignore_fields, variant):
                     grp_fields[key] = val
         grp.fields = grp_fields
 
-    # Sort the founded groups by BOM_ORDER definition.
-    new_component_groups = groups_sort(new_component_groups)
-
     # Now return the list of identical part groups.
     return new_component_groups, prj_info
 
@@ -554,6 +551,9 @@ def create_spreadsheet(parts, prj_info, spreadsheet_filename, user_fields, varia
     '''Create a spreadsheet using the info for the parts (including their HTML trees).'''
 
     logger.log(DEBUG_OVERVIEW, 'Create spreadsheet...')
+
+    # Sort the founded groups by BOM_ORDER definition.
+    parts = groups_sort(parts)
 
     DEFAULT_BUILD_QTY = 100  # Default value for number of boards to build.
     WORKSHEET_NAME = os.path.splitext(os.path.basename(spreadsheet_filename))[0] # Default name for pricing worksheet.

--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -552,6 +552,10 @@ def create_spreadsheet(parts, prj_info, spreadsheet_filename, user_fields, varia
 
     logger.log(DEBUG_OVERVIEW, 'Create spreadsheet...')
 
+    # Collapse de references.
+    for part in parts:
+        part.refs = collapse_refs(part.refs)
+
     # Sort the founded groups by BOM_ORDER definition.
     parts = groups_sort(parts)
 
@@ -805,7 +809,7 @@ def collapse_refs(refs):
                                                                      num))
 
                 # Return the collapsed par references.
-    return collapsed_refs
+    return ','.join(collapsed_refs)
 
 
 def add_globals_to_worksheet(wks, wrk_formats, start_row, start_col,
@@ -940,7 +944,7 @@ Yellow -> Enough parts available, but haven't purchased enough.''',
 
         # Enter part references.
         wks.write_string(row, start_col + columns['refs']['col'],
-                         ','.join(collapse_refs(part.refs)))
+                         part.refs)
 
         # Enter more static data for the part.
         for field in list(columns.keys()):

--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -88,6 +88,7 @@ distributors = distributor_imports.distributors
 from . import eda_tools as eda_tools_imports
 eda_tools = eda_tools_imports.eda_tools
 subpart_qty = eda_tools_imports.subpart_qty
+groups_sort = eda_tools_imports.groups_sort
 from .eda_tools.eda_tools import SUB_SEPRTR
 
 # Regular expression for detecting part reference ids consisting of a
@@ -269,7 +270,7 @@ def create_spreadsheet(parts, prj_info, spreadsheet_filename, user_fields, varia
         part.refs = collapse_refs(part.refs)
 
     # Sort the founded groups by BOM_ORDER definition.
-    parts = groups_sort(parts)
+    #parts = groups_sort(parts)
 
     DEFAULT_BUILD_QTY = 100  # Default value for number of boards to build.
     WORKSHEET_NAME = os.path.splitext(os.path.basename(spreadsheet_filename))[0] # Default name for pricing worksheet.


### PR DESCRIPTION
Improved by the issue #84: spreadsheet order groups fixed
Multipart components issue #34 ready to use
`altium` module moved to `eda_tools` folders to group the routines and configurations (issue #84 not already implemented in altium module)