### PR TITLE
Include variant-specific user-requested fields.

### DIFF
--- a/kicost/eda_tools/altium/altium.py
+++ b/kicost/eda_tools/altium/altium.py
@@ -23,7 +23,7 @@ from ...kicost import SEPRTR # Delimiter between library:component, distributor:
 class IdenticalComponents(object):
     pass
 
-def get_part_groups(in_file, ignore_fields, variant):
+def get_part_groups(in_file, ignore_fields, variant, user_fields):
     '''Get groups of identical parts from an XML file and return them as a dictionary.'''
 
     ign_fields = [str(f.lower()) for f in ignore_fields]

--- a/kicost/eda_tools/generic_csv/generic_csv.py
+++ b/kicost/eda_tools/generic_csv/generic_csv.py
@@ -60,7 +60,7 @@ GENERIC_REF = 'generic' # Generic text reference to components.
 class IdenticalComponents(object):
     pass
 
-def get_part_groups(in_file, ignore_fields, variant):
+def get_part_groups(in_file, ignore_fields, variant, user_fields):
     '''Get groups of identical parts from an generic CSV file and return them as a dictionary.'''
     # No `variant` of ignore field is used in this function, the input is just kept by compatibily.
     # Enven not `ignore_filds` to be ignored.

--- a/kicost/eda_tools/kicad/kicad.py
+++ b/kicost/eda_tools/kicad/kicad.py
@@ -48,7 +48,7 @@ class IdenticalComponents(object):
     pass
 
 
-def get_part_groups(in_file, ignore_fields, variant):
+def get_part_groups(in_file, ignore_fields, variant, user_fields):
     '''Get groups of identical parts from an XML file and return them as a dictionary.'''
 
     ign_fields = [str(f.lower()) for f in ignore_fields]
@@ -81,10 +81,12 @@ def get_part_groups(in_file, ignore_fields, variant):
                         # If the field name isn't for a manufacturer's part
                         # number or a distributors catalog number, then add
                         # it to 'local' if it doesn't start with a distributor
-                        # name and colon.
+                        # name and colon and is not requested for inclusion
+                        # by the user.
                         if name not in ('manf#', 'manf') and name[:-1] not in distributors:
                             if SEPRTR not in name: # This field has no distributor.
-                                name = 'local:' + name # Assign it to a local distributor.
+                                if name not in user_fields: # This field was not requested
+                                    name = 'local:' + name # Assign it to a local distributor.
                         fields[name] = str(f.string)
 
         except AttributeError:

--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -127,7 +127,7 @@ def kicost(in_file, out_filename, user_fields, ignore_fields, variant, num_proce
     prj_info = list()
     for i_prj in range(len(in_file)):
         eda_tool_module = getattr(eda_tools_imports, eda_tool_name[i_prj])
-        p, info = eda_tool_module.get_part_groups(in_file[i_prj], ignore_fields, variant[i_prj])
+        p, info = eda_tool_module.get_part_groups(in_file[i_prj], ignore_fields, variant[i_prj], user_fields)
         # Add the project indentifier in the references.
         for i_g in range(len(p)):
             p[i_g].qty = 'Board{}Qty'.format(i_prj) # 'Board{}Qty' string is used to put name quantity cells of the spreadsheet.


### PR DESCRIPTION
(Re: Issue #110)

When old-style variants (i.e. fields with names like kicost.V1:manf)
are used to assign different part numbers based on the variant selection,
and variant-specific values are assigned to fields requested for inclusion
with the --fields option (e.g., assigning different internal part numbers
with fields like kicost.V1:mypartnum), the correct user-requested
field values were not consistently included in BOM lines. This change
makes sure that user-requested fields are not renamed with a "local:"
prefix, so that the normal variant-specific selection of field
values will be applied to those user-requested fields.