### PR TITLE
Fixed various Python 2.7 syntax error exceptions

### DIFF
--- a/kicost/distributors/distributor.py
+++ b/kicost/distributors/distributor.py
@@ -57,7 +57,7 @@ from . import distributor_dict
 
 import os, re
 
-class distributor:
+class distributor(object):
     start_time = time.time()
     def __init__(self, name, domain, scrape_retries, throttle_delay):
         self.name = name

--- a/kicost/distributors/local/local.py
+++ b/kicost/distributors/local/local.py
@@ -46,6 +46,7 @@ class dist_local(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_local, self).__init__(name, None, scrape_retries, throttle_delay)
 
+    @staticmethod
     def create_part_html(parts, distributors, logger):
         '''@brief Create HTML page containing info for local (non-webscraped) parts.
         @param parts `list()` of parts.

--- a/kicost/distributors/rs/rs.py
+++ b/kicost/distributors/rs/rs.py
@@ -1,3 +1,4 @@
+# vim: set fileencoding=utf8 :
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Júnior

--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -315,14 +315,14 @@ def kicost(in_file, eda_tool_name, out_filename,
             # Package part data for passing to each process.
             # pool.async_apply needs at least two arguments per function so add dummy argument
             # (otherwise it fails with "arguments after * must be an iterable, not ...")
-            arg_sets = [(distributor_dict[d]['instance'], None) for d in distributor_dict]
+            arg_sets = [(distributor_dict[d]['instance'], scraping_progress) for d in distributor_dict]
 
-            def mt_scrape_part(inst, dummy):
+            def mt_scrape_part(inst, progress):
                 logger.log(DEBUG_OVERVIEW, "Scraping "+ inst.name)
                 retval = list()
                 for i in range(len(parts)):
                     retval.append(inst.scrape_part(i, parts[i]))
-                    scraping_progress.update(1)
+                    progress.update(1)
                 return retval
 
             # Start the web scraping processes, one for each part.


### PR DESCRIPTION
Fixes #267.
However, in Python 2.7 there is now an exception (again) when the program terminates.
The `del` statement in kicost.py line 348-351 which should fix this seems to be ignored now.
Nevertheless, the spreadsheet is correctly written.