### PR TITLE
Correctly implemented TME AJAX POST request on new fake_browser architecture.

### DIFF
--- a/kicost/distributors/distributor.py
+++ b/kicost/distributors/distributor.py
@@ -36,19 +36,6 @@ from ..eda_tools.eda_tools import order_refs # To better print the warnings abou
 from . import fake_browser
 
 import http.client # For web scraping exceptions.
-if sys.version_info>=(3,0):
-    # This is for Python 3.
-    from urllib.parse import urlencode, quote_plus as urlquote, urlsplit, urlunsplit
-    from urllib.request import urlopen, Request
-    import urllib.error
-    WEB_SCRAPE_EXCEPTIONS = (urllib.error.URLError, http.client.HTTPException)
-else:
-    # This is for Python 2.
-    from urlparse import urlsplit, urlunsplit
-    from urllib import urlencode, quote_plus as urlquote
-    from urllib2 import urlopen, Request
-    import urllib2
-    WEB_SCRAPE_EXCEPTIONS = (urllib2.URLError, http.client.HTTPException)
 
 from ..globals import logger, DEBUG_OVERVIEW, DEBUG_DETAILED, DEBUG_OBSESSIVE # Debug configurations.
 from ..globals import SEPRTR

--- a/kicost/distributors/fake_browser.py
+++ b/kicost/distributors/fake_browser.py
@@ -33,21 +33,6 @@ import requests
 
 from ..globals import DEBUG_OVERVIEW, DEBUG_DETAILED, DEBUG_OBSESSIVE, DEBUG_HTTP_HEADERS, DEBUG_HTTP_RESPONSES
 
-if sys.version_info>=(3,0):
-    # This is for Python 3
-    from urllib.parse import urlencode, quote_plus as urlquote, urlsplit, urlunsplit
-    from urllib.request import urlopen, Request
-    import urllib.error
-    WEB_SCRAPE_EXCEPTIONS = (urllib.error.URLError, http.client.HTTPException)
-else:
-    # This is for Python 2
-    from urlparse import urlsplit, urlunsplit
-    from urllib import urlencode, quote_plus as urlquote
-    from urllib2 import urlopen, Request
-    import urllib2
-    WEB_SCRAPE_EXCEPTIONS = (urllib2.URLError, http.client.HTTPException)
-
-
 def get_user_agent():
     ''' The default user_agent_list comprises chrome, IE, firefox, Mozilla, opera, netscape.
       You can find more user agent strings at https://techblog.willshouse.com/2012/01/03/most-common-user-agents/.

--- a/kicost/distributors/tme/tme.py
+++ b/kicost/distributors/tme/tme.py
@@ -37,7 +37,7 @@ from ...globals import logger, DEBUG_OVERVIEW, DEBUG_DETAILED, DEBUG_OBSESSIVE, 
 
 from .. import distributor, distributor_dict
 
-from urllib.parse import quote_plus as urlquote, urlencode
+from urllib.parse import quote_plus as urlquote
 
 class dist_tme(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):

--- a/kicost/distributors/tme/tme.py
+++ b/kicost/distributors/tme/tme.py
@@ -49,12 +49,9 @@ class dist_tme(distributor.distributor):
            @param pn `str()` part number
            @return (html, quantity avaliable)
         '''
-        data = urlencode({
-            'symbol': pn,
-            'currency': 'USD'
-        }).encode("utf-8")
+        data = { 'symbol': pn, 'currency': 'USD'}
         try:
-            html = self.browser.ajax_request('https://www.tme.eu/en/_ajax/ProductInformationPage/_getStocks.html', data=data)
+            html = self.browser.ajax_request('https://www.tme.eu/en/_ajax/ProductInformationPage/_getStocks.html', data)
         except: # Couldn't get a good read from the website.
             self.logger.log(DEBUG_OBSESSIVE,'No AJAX data for {} from {}'.format(pn, 'TME'))
             return None, None


### PR DESCRIPTION
The old implementation from #269 did not respect fake_browsers session state (cookies, timing, user_agent, ...).
This pull request fixes that issue. 

Additionally, this removed unused liburl imports and removes unused fake_browser `add_headers` support.