### PR TITLE
Fix wrong Mouser scraping results.

### DIFF
--- a/kicost/distributors/digikey/digikey.py
+++ b/kicost/distributors/digikey/digikey.py
@@ -45,6 +45,7 @@ class dist_digikey(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_digikey, self).__init__(name, distributor_dict[name]['site']['url'],
             scrape_retries, throttle_delay)
+        self.browser.start_new_session()
 
     @staticmethod
     def dist_init_distributor_dict():

--- a/kicost/distributors/fake_browser.py
+++ b/kicost/distributors/fake_browser.py
@@ -150,6 +150,7 @@ class fake_browser:
 
         self.scrape_retries = scrape_retries
         self.logger = logger
+        self.ret_url = None
 
         self.start_new_session(False)
 
@@ -219,6 +220,8 @@ class fake_browser:
                         " Starting new session for %s" % self.domain)
                     continue
 
+                # Store last accessed URL to allow check for regional redirect.
+                self.ret_url = resp.url
                 html = resp.text
                 break
             except Exception as ex:

--- a/kicost/distributors/fake_browser.py
+++ b/kicost/distributors/fake_browser.py
@@ -151,9 +151,9 @@ class fake_browser:
         self.scrape_retries = scrape_retries
         self.logger = logger
 
-        self.start_new_session()
+        self.start_new_session(False)
 
-    def start_new_session(self):
+    def start_new_session(self, scrape_base_url=True):
         self.userAgent = get_user_agent()
 
         # Use "requests" instead of "urllib" because "urllib" does not allow
@@ -163,11 +163,12 @@ class fake_browser:
 
         # Restore configuration cookies from previous session.
         for c in self.config_cookies:
-            print("Restore cookie: %s", c)
+            self.logger.log(DEBUG_OBSESSIVE, "Restore cookie: %s", c)
             self.session.cookies.set(c[1], c[2], domain=c[0])
 
-        self.scrape_URL(self.domain, retry=False)
-        self.show_cookies()
+        if scrape_base_url:
+            self.scrape_URL(self.domain, retry=False)
+            self.show_cookies()
 
     def show_cookies(self):
         for x in self.session.cookies:

--- a/kicost/distributors/farnell/farnell.py
+++ b/kicost/distributors/farnell/farnell.py
@@ -46,6 +46,7 @@ class dist_farnell(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_farnell, self).__init__(name, distributor_dict[name]['site']['url'],
             scrape_retries, throttle_delay)
+        self.browser.start_new_session()
 
     @staticmethod
     def dist_init_distributor_dict():

--- a/kicost/distributors/mouser/mouser.py
+++ b/kicost/distributors/mouser/mouser.py
@@ -43,7 +43,10 @@ class dist_mouser(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_mouser, self).__init__(name, distributor_dict[name]['site']['url'],
             scrape_retries, throttle_delay)
-        self.browser.add_cookie('.mouser.com', 'preferences', 'ps=www2&pl=en-US&pc_www2=USDe')
+
+        self.browser.add_cookie('.mouser.com', 'preferences', \
+            'pl=en-GB&pc_eu=USDe&pc_www=USDe&pc_www2=USDe&&s=')
+        self.browser.start_new_session()
 
     @staticmethod
     def dist_init_distributor_dict():

--- a/kicost/distributors/newark/newark.py
+++ b/kicost/distributors/newark/newark.py
@@ -43,6 +43,7 @@ class dist_newark(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_newark, self).__init__(name, distributor_dict[name]['site']['url'],
             scrape_retries, throttle_delay)
+        self.browser.start_new_session()
 
     @staticmethod
     def dist_init_distributor_dict():

--- a/kicost/distributors/rs/rs.py
+++ b/kicost/distributors/rs/rs.py
@@ -45,6 +45,7 @@ class dist_rs(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_rs, self).__init__(name, distributor_dict[name]['site']['url'],
             scrape_retries, throttle_delay)
+        self.browser.start_new_session()
 
     @staticmethod
     def dist_init_distributor_dict():

--- a/kicost/distributors/tme/tme.py
+++ b/kicost/distributors/tme/tme.py
@@ -44,6 +44,7 @@ class dist_tme(distributor.distributor):
     def __init__(self, name, scrape_retries, throttle_delay):
         super(dist_tme, self).__init__(name, distributor_dict[name]['site']['url'],
             scrape_retries, throttle_delay)
+        self.browser.start_new_session()
 
     @staticmethod
     def dist_init_distributor_dict():


### PR DESCRIPTION
Mouser ignored regional settings and defaulted to EUR instead of USD prices.
EUR prices use ',' as decimal separator which lead to completely wrong results.

Also started working on Mouser dist_define_locale_currency implementation.