### PR TITLE
Increase fake_browser receive timeout.

### DIFF
--- a/kicost/distributors/fake_browser.py
+++ b/kicost/distributors/fake_browser.py
@@ -198,9 +198,9 @@ class fake_browser:
                 self.throttle_timeout = time.time() + self.throttle_delay
 
                 if postData != None:
-                    resp = self.session.post(url, timeout=5, data=postData)
+                    resp = self.session.post(url, timeout=15, data=postData)
                 else:
-                    resp = self.session.get(url, timeout=5)
+                    resp = self.session.get(url, timeout=15)
 
                 self.logger.log(DEBUG_HTTP_HEADERS, "Request headers: %s" % resp.request.headers)
                 self.logger.log(DEBUG_HTTP_HEADERS, "Response headers: %s" % resp.headers)


### PR DESCRIPTION
For some reason, the Digikey part "A-DS 09 PP/Z" takes some more time to respond to the search query.
Increasing the read timeout fixes #264.