### PR TITLE
Don't add comma between each ref character in merged fields

### DIFF
--- a/kicost/edas/tools.py
+++ b/kicost/edas/tools.py
@@ -332,7 +332,7 @@ def group_parts(components, fields_merge):
                     if f=='desc' and len(ocurrences)==2 and '' in ocurrences.keys():
                         value = ''.join(list(ocurrences.keys()))
                     else:
-                        value = SGROUP_SEPRTR.join( [','.join( order_refs(r) ) + SEPRTR + ' ' + t for t,r in ocurrences.items()] )
+                        value = SGROUP_SEPRTR.join( [order_refs(r) + SEPRTR + ' ' + t for t,r in ocurrences.items()] )
                     for r in grp.refs:
                         components[r][f] = value
     #print('\n\n\n3++++++++++++++',len(new_component_groups))


### PR DESCRIPTION
E.g. for an extra field added with --fields Notes,
merged output should be something like

C1,C2: Note 1
C3,C4: Note 2

instead of

C,1,,C,2: Note 1
C,3,,C,4: Note 2