### PR TITLE
Reverted lxml dependency removal.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4 >= 4.3.2 # Deal with HTML and XML tags.
-#lxml >= 3.7.2
+lxml >= 3.7.2 # Used by beautifulsoup4, but optional.
 XlsxWriter >= 0.7.3 # Write the XLSX output file.
 future # For print statements.
 tqdm >= 4.30.0 # Progress bar.


### PR DESCRIPTION
The lxml dependency is a bs4 dependency. But we must require it.
I think using `beautifulsoup4[lxml]` is the best, but don't know how
to test it.
On Debian this is forced by python3-bs4, but when using pip the lxml
dependency is optional.
Sorry for the noise.