### PR TITLE
Fix for invalid escape sequences in strings

### DIFF
--- a/kicost/distributors/api_partinfo_kitspace.py
+++ b/kicost/distributors/api_partinfo_kitspace.py
@@ -72,7 +72,7 @@ QUERY_ANSWER = '''
         }
 '''
 #Informations not used: type,specs{key, name, value},image {url, credit_string, credit_url},stock_location
-QUERY_ANSWER = re.sub('[\s\n]', '', QUERY_ANSWER)
+QUERY_ANSWER = re.sub(r'[\s\n]', '', QUERY_ANSWER)
 
 QUERY_PART = 'query ($input: MpnInput!) { part(mpn: $input) {' + QUERY_ANSWER + '} }'
 QUERY_MATCH = 'query ($input: [MpnOrSku]!){ match(parts: $input) {' + QUERY_ANSWER + '} }'
@@ -123,10 +123,10 @@ class api_partinfo_kitspace(distributor_class):
             return next((k for k, v in input_dict.items() if v == value), None)
         distributors = ([find_key(dist_xlate, d) for d in distributors])
         
-        query_type = re.sub('\{DISTRIBUTORS\}', '["'+ '","'.join(distributors) +'"]' , query_type)
+        query_type = re.sub(r'\{DISTRIBUTORS\}', '["'+ '","'.join(distributors) +'"]' , query_type)
         #r = requests.post(QUERY_URL, {"query": QUERY_SEARCH, "variables": variables}) #TODO future use for ISSUE #17
         variables = re.sub('\'', '\"', str(query_parts))
-        variables = re.sub('\s', '', variables)
+        variables = re.sub(r'\s', '', variables)
         # Python 2 prepends a 'u' before the query strings and this makes PartInfo
         # complain, so remove them.
         variables = re.sub(':u"', ':"', variables)

--- a/kicost/distributors/distributors_info.py
+++ b/kicost/distributors/distributors_info.py
@@ -39,7 +39,7 @@ distributors_info = {
             'name': 'Digi-Key', 'url': 'https://www.digikey.com/',
             'format': {'font_color': 'white', 'bg_color': '#CC0000'}, # Digi-Key red.
         },
-        'ignore_cat#_re': '.+(DKR\-ND|\-6\-ND)$', # Use to ignore some catalogue/stock code format. In the Digikey distributor it is used to ignore the Digi-reel package.
+        'ignore_cat#_re': r'.+(DKR\-ND|\-6\-ND)$', # Use to ignore some catalogue/stock code format. In the Digikey distributor it is used to ignore the Digi-reel package.
     },
     'farnell': {
         'type': 'web',

--- a/kicost/edas/eda_altium.py
+++ b/kicost/edas/eda_altium.py
@@ -74,7 +74,7 @@ eda_dict.update(
             # Formatting file match .
             'file': {
                 'extension': '.xml', # File extension.
-                'content': '\<GRID[\s\S]+<COLUMNS>[\s\S]+<COLUMN[\s\S]+<\/COLUMNS>[\s\S]+<ROWS>[\s\S]+\<ROW[\s\S]+\<\/ROWS>[\s\S]+\<\/GRID>' # Regular expression content match.
+                r'content': r'\<GRID[\s\S]+<COLUMNS>[\s\S]+<COLUMN[\s\S]+<\/COLUMNS>[\s\S]+<ROWS>[\s\S]+\<ROW[\s\S]+\<\/ROWS>[\s\S]+\<\/GRID>' # Regular expression content match.
             }
         }
     }
@@ -148,7 +148,7 @@ def get_part_groups(in_file, ignore_fields, variant):
                 # Now look for fields that start with 'kicost' and possibly
                 # another dot-separated variant field and store their values.
                 # Anything else is in a non-kicost namespace.
-                key_re = 'kicost(\.{})?:(?P<name>.*)'.format(variant)
+                key_re = r'kicost(\.{})?:(?P<name>.*)'.format(variant)
                 mtch = re.match(key_re, hdr, flags=re.IGNORECASE)
                 if mtch:
                     # The field name is anything that came after the leading
@@ -193,12 +193,12 @@ def get_part_groups(in_file, ignore_fields, variant):
         refs, fields = extract_fields_row(row, variant, header)
         for i in range(len(refs)):
             ref = refs[i]
-            ref = re.sub('\+$', 'p', ref) # Finishing "+".
+            ref = re.sub(r'\+$', 'p', ref) # Finishing "+".
             ref = re.sub(PART_REF_REGEX_NOT_ALLOWED, '', ref) # Generic special characters not allowed. To work around #ISSUE #89.
-            ref = re.sub('\-+', '-', ref) # Double "-".
-            ref = re.sub('^\-', '', ref) # Starting "-".
-            ref = re.sub('\-$', 'n', ref) # Finishing "-".
-            if not re.search('\d$', ref):
+            ref = re.sub(r'\-+', '-', ref) # Double "-".
+            ref = re.sub(r'^\-', '', ref) # Starting "-".
+            ref = re.sub(r'\-$', 'n', ref) # Finishing "-".
+            if not re.search(r'\d$', ref):
                 ref += '0'
             accepted_components[ re.sub(PART_REF_REGEX_NOT_ALLOWED, '', ref) ] = fields[i]
 

--- a/kicost/edas/eda_kicad.py
+++ b/kicost/edas/eda_kicad.py
@@ -52,7 +52,7 @@ eda_dict.update(
             # Formatting file match.
             'file': {
                 'extension': '.xml', # File extension.
-                'content': '<tool\>Eeschema.*\<\/tool\>' # Regular expression content match.
+                'content': r'<tool\>Eeschema.*\<\/tool\>' # Regular expression content match.
                 }
         }
     }
@@ -91,7 +91,7 @@ def get_part_groups(in_file, ignore_fields, variant):
                     # Now look for fields that start with 'kicost' and possibly
                     # another dot-separated variant field and store their values.
                     # Anything else is in a non-kicost namespace.
-                    key_re = 'kicost(\.(?P<variant>.*))?:(?P<name>.*)'
+                    key_re = r'kicost(\.(?P<variant>.*))?:(?P<name>.*)'
                     mtch = re.match(key_re, name, flags=re.IGNORECASE)
                     if mtch:
                         v = mtch.group('variant')

--- a/kicost/edas/tools.py
+++ b/kicost/edas/tools.py
@@ -874,9 +874,9 @@ def split_refs(text):
                 split = [designator_name +base_split_nums+str(split[i]) for i in range(len(split)) ]
                 
                 refs += split
-            elif re.search(r'[/\\\]', ref):
+            elif re.search(r'[/\\]', ref):
                 designator_name = re.findall(r'^\D+',ref)[0]
-                split_nums = [re.sub('^'+designator_name, '', i) for i in re.split(r'[/\\\]',ref)]
+                split_nums = [re.sub('^'+designator_name, '', i) for i in re.split(r'[/\\]',ref)]
                 refs += [designator_name+i for i in split_nums]
             else:
                 refs += [ref.strip()]
@@ -884,7 +884,7 @@ def split_refs(text):
             # The designator name is not for a group of components and 
             # "\", "/" or "-" is part of the name. This characters have
             # to be removed.
-            ref = re.sub(r'[\-\/\\\]', '', ref.strip())
+            ref = re.sub(r'[\-\/\\]', '', ref.strip())
             if not re.search(PART_REF_REGEX, ref).group('num'):
                 # Add a '0' number at the end to be compatible with KiCad/KiCost
                 # ref strings. This may be missing in the hand made BoM.

--- a/kicost/edas/tools.py
+++ b/kicost/edas/tools.py
@@ -53,7 +53,7 @@ PRJ_SEPRTR = ';' # Separator between projects when collapsed and grouped the par
 BOM_ORDER = 'u,q,d,t,y,x,c,r,s,j,p,cnn,con'
 
 # Characters removed from references when read the files.
-PART_REF_REGEX_NOT_ALLOWED = '[\+\(\)\*\{}]'.format(SEPRTR)
+PART_REF_REGEX_NOT_ALLOWED = r'[\+\(\)\*\{}]'.format(SEPRTR)
 # Regular expression for detecting part reference ids consisting of a
 # prefix of letters followed by a sequence of digits, such as 'LED10'
 # or a sequence of digits followed by a subpart number like 'CONN1#3'.
@@ -65,8 +65,8 @@ PART_REF_REGEX_NOT_ALLOWED = '[\+\(\)\*\{}]'.format(SEPRTR)
 # In the case of multiple project BOM files, the references are
 # modified by adding the project number identification followed
 # by `SEPRTR` definition.
-PART_REF_REGEX_SPECIAL_CHAR_REF = '\+\-\=\s\_\.\(\)\$\*\&' # Used in next definition only (because repeat).
-PART_REF_REGEX = re.compile('(?P<prefix>({p_str}(?P<prj>\d+){p_sp})?(?P<ref>[a-z{sc}\d]*[a-z{sc}]))(?P<num>((?P<ref_num>\d+(\.\d+)?)({sp}(?P<subpart_num>\d+))?)?)'.format(p_str=PRJ_STR_DECLARE, p_sp=PRJPART_SPRTR,
+PART_REF_REGEX_SPECIAL_CHAR_REF = r'\+\-\=\s\_\.\(\)\$\*\&' # Used in next definition only (because repeat).
+PART_REF_REGEX = re.compile(r'(?P<prefix>({p_str}(?P<prj>\d+){p_sp})?(?P<ref>[a-z{sc}\d]*[a-z{sc}]))(?P<num>((?P<ref_num>\d+(\.\d+)?)({sp}(?P<subpart_num>\d+))?)?)'.format(p_str=PRJ_STR_DECLARE, p_sp=PRJPART_SPRTR,
                                 sc=PART_REF_REGEX_SPECIAL_CHAR_REF, sp=SUB_SEPRTR), re.IGNORECASE)
 
 # Generate a dictionary to translate all the different ways people might want
@@ -434,7 +434,7 @@ def groups_sort(new_component_groups):
 
     logger.log(DEBUG_OVERVIEW, 'Sorting the groups for better visualization...')
 
-    ref_identifiers = re.split('(?<![\W\*\/])\s*,\s*|\s*,\s*(?![\W\*\/])',
+    ref_identifiers = re.split(r'(?<![\W\*\/])\s*,\s*|\s*,\s*(?![\W\*\/])',
                 BOM_ORDER, flags=re.IGNORECASE)
     component_groups_order_old = list( range(0,len(new_component_groups)) )
     component_groups_order_new = list()
@@ -696,7 +696,7 @@ def manf_code_qtypart(subpart):
        manufacture / distributor. Test if was pre or post
        multiplied by a constant.
        
-       Setting QTY_SEPRTR as '\:', we have
+       Setting QTY_SEPRTR as ':', we have
        ' 4.5 : ADUM3150BRSZ-RL7' -> ('4.5', 'ADUM3150BRSZ-RL7')
        '4/5  : ADUM3150BRSZ-RL7' -> ('4/5', 'ADUM3150BRSZ-RL7')
        '7:ADUM3150BRSZ-RL7' -> ('7', 'ADUM3150BRSZ-RL7')
@@ -711,7 +711,7 @@ def manf_code_qtypart(subpart):
     strings = re.split(QTY_SEPRTR, subpart)
     if len(strings)==2:
         # Search for numbers, matching with simple, frac and decimal ones.
-        num_format = re.compile("^\s*[\-\+]?\s*[0-9]*\s*[\.\/]*\s*?[0-9]*\s*$")
+        num_format = re.compile(r"^\s*[\-\+]?\s*[0-9]*\s*[\.\/]*\s*?[0-9]*\s*$")
         string0_test = re.match(num_format, strings[0])
         string1_test = re.match(num_format, strings[1])
         if string0_test and not(string1_test):
@@ -724,7 +724,7 @@ def manf_code_qtypart(subpart):
             # May be founded a just numeric manufacture/distributor part,
             # in this case, the quantity is a shortest string not
             #considering "." and "/" marks.
-            if len(re.sub('[\.\/]','',strings[0])) < len(re.sub('[\.\/]','',strings[1])):
+            if len(re.sub(r'[\.\/]','',strings[0])) < len(re.sub(r'[\.\/]','',strings[1])):
                 qty = strings[0].strip()
                 part = strings[1].strip()
             else:
@@ -753,7 +753,7 @@ def order_refs(refs, collapse=True):
         # e.g.: 3,4,7,8,9,10,11,13,14 => 3,4,7-11,13,14
 
         def get_refnum(refnum):
-            return int(re.match('\d+', refnum).group(0))
+            return int(re.match(r'\d+', refnum).group(0))
 
         def to_int(n):
             try:
@@ -816,7 +816,7 @@ def order_refs(refs, collapse=True):
     else:
         for prefix in list(prefix_nums.keys()):
             def get_refnum(refnum):
-                return int(re.match('\d+', refnum).group(0))
+                return int(re.match(r'\d+', refnum).group(0))
             prefix_nums[prefix].sort(key=get_refnum)
 
     # Combine the prefixes and number ranges back into part references.
@@ -856,27 +856,27 @@ def split_refs(text):
         #ref = re.sub('\-+', '-', ref) # Double "-".
         #ref = re.sub('^\-', '', ref) # Starting "-".
         #ref = re.sub('\-$', 'n', ref) # Finishing "-".
-        if re.search('^\w+\d', ref):
+        if re.search(r'^\w+\d', ref):
             if re.search('-', ref):
-                designator_name = re.findall('^\D+', ref)[0]
+                designator_name = re.findall(r'^\D+', ref)[0]
                 split_nums = re.split('-', ref)
-                designator_name += ''.join( re.findall('^d*\W', split_nums[0] ) )
+                designator_name += ''.join( re.findall(r'^d*\W', split_nums[0] ) )
                 split_nums = [re.sub(designator_name,'',split_nums[i]) for i in range(len(split_nums))]
                 
                 # Some EDAs may use some separator in the reference numeric parts, as
                 # Altium that use "." (or even other) e.g. "R2.1,R2.2" to the same "R2"
                 # replicated between schematics / rooms.
-                base_split_nums = ''.join( re.findall('^\d+\D', split_nums[0]) )
-                split_nums = [''.join( re.findall('\D*(\d+)$', n) ) for n in split_nums]
+                base_split_nums = ''.join( re.findall(r'^\d+\D', split_nums[0]) )
+                split_nums = [''.join( re.findall(r'\D*(\d+)$', n) ) for n in split_nums]
                 
                 split = list( range( int(split_nums[0]), int(split_nums[1])+1 ) )
                 #split = [designator_name+str(split[i]) for i in range(len(split)) ]
                 split = [designator_name +base_split_nums+str(split[i]) for i in range(len(split)) ]
                 
                 refs += split
-            elif re.search('[/\\\]', ref):
-                designator_name = re.findall('^\D+',ref)[0]
-                split_nums = [re.sub('^'+designator_name, '', i) for i in re.split('[/\\\]',ref)]
+            elif re.search(r'[/\\\]', ref):
+                designator_name = re.findall(r'^\D+',ref)[0]
+                split_nums = [re.sub('^'+designator_name, '', i) for i in re.split(r'[/\\\]',ref)]
                 refs += [designator_name+i for i in split_nums]
             else:
                 refs += [ref.strip()]
@@ -884,7 +884,7 @@ def split_refs(text):
             # The designator name is not for a group of components and 
             # "\", "/" or "-" is part of the name. This characters have
             # to be removed.
-            ref = re.sub('[\-\/\\\]', '', ref.strip())
+            ref = re.sub(r'[\-\/\\\]', '', ref.strip())
             if not re.search(PART_REF_REGEX, ref).group('num'):
                 # Add a '0' number at the end to be compatible with KiCad/KiCost
                 # ref strings. This may be missing in the hand made BoM.

--- a/kicost/kicad_config.py
+++ b/kicost/kicad_config.py
@@ -231,7 +231,7 @@ def bom_plugin_remove_entry(name, re_flags=re.IGNORECASE):
             else:
                 for entry in plugin[2:]:
                     if entry[0]==sexpdata.Symbol('opts') and\
-                        re.findall('nickname\s*=\s*'+name, entry[1], re_flags):
+                        re.findall(r'nickname\s*=\s*'+name, entry[1], re_flags):
                             changes = True
                             continue # The name is in the 'nickname'.
                 new_list.append(plugin) # This plugin remains on the list.
@@ -262,7 +262,7 @@ def bom_plugin_add_entry(name, cmd, nickname=None, re_flags=re.IGNORECASE, put_f
                     return # Plugin already added and don't have nickname.
                 for entry in plugin[2:]:
                     if entry[0]==sexpdata.Symbol('opts') and\
-                        re.findall('nickname\s*=\s*'+nickname, entry[1], re_flags):
+                        re.findall(r'nickname\s*=\s*'+nickname, entry[1], re_flags):
                             return # Plugin already added with this nickname.
             new_list.append(plugin)
     if not nickname:

--- a/kicost/kicost_gui.py
+++ b/kicost/kicost_gui.py
@@ -581,7 +581,7 @@ class formKiCost(formKiCost_raw):
             try:
                 response = requests.get(PAGE_UPDATE)
                 html = response.text
-                offical_last_version = re.findall('kicost (\d+\.\d+\.\d+)', str(html), flags=re.IGNORECASE)[0]
+                offical_last_version = re.findall(r'kicost (\d+\.\d+\.\d+)', str(html), flags=re.IGNORECASE)[0]
                 if StrictVersion(offical_last_version) > StrictVersion(__version__):
                     self.m_button_check_updates.SetLabel(u"Found v{}.".format(offical_last_version) )
                     #self.m_staticText_update.Bind(wx.EVT_LEFT_UP, self.m_staticText_update_click)
@@ -766,7 +766,7 @@ class formKiCost(formKiCost_raw):
         args.translate_fields = str_to_arg(['--translate_fields']).split()
         args.variant = str_to_arg(['--variant', '-var'])
         try:
-            args.currency = re.findall('\((\w{3}) .*\).*', self.m_comboBox_currency.GetValue())[0]
+            args.currency = re.findall(r'\((\w{3}) .*\).*', self.m_comboBox_currency.GetValue())[0]
         except IndexError:
             pass # Doesn't work under Python 2 so I'm just ignoring it.
 
@@ -907,11 +907,11 @@ class formKiCost(formKiCost_raw):
 
             def str_to_wxpoint(s):
                 '''Convert a string tuple into a  wxPoint.'''
-                p = re.findall('\d+', s)
+                p = re.findall(r'\d+', s)
                 return wx.Point(int(p[0]), int(p[1]))
             def str_to_wxsize(s):
                 '''Convert a string tuple into a  wxRect.'''
-                p = re.findall('\d+', s)
+                p = re.findall(r'\d+', s)
                 return wx.Size(int(p[0]), int(p[1]))
 
             entryCount = 0
@@ -1042,7 +1042,7 @@ class formKiCost(formKiCost_raw):
         history_file = open(os.path.join(kicostPath, 'HISTORY.rst') )
         history = history_file.read()
         history_file.close()
-        search_news = re.compile('History\s+[\=\-\_]+\s+(?P<version>[\w\.]+)\s*\((?P<data>.+)\)\s+[\=\-\_]+\s+(?P<news>(?:\n|.)*?)\s+[\d\.]+', re.IGNORECASE)
+        search_news = re.compile(r'History\s+[\=\-\_]+\s+(?P<version>[\w\.]+)\s*\((?P<data>.+)\)\s+[\=\-\_]+\s+(?P<news>(?:\n|.)*?)\s+[\d\.]+', re.IGNORECASE)
         news = re.search(search_news, history)
         dlg = wx.MessageDialog(self,
                                news.group('news'),
@@ -1088,9 +1088,9 @@ def kicost_gui(files=None):
                 # Second https://github.com/tqdm/tqdm/issues/172 is necessary this work around,
                 # until they finish the v5.
                 wx.CallAfter(frame.m_gauge_process.SetValue,
-                    int(re.findall('^.*\s(\d+)\%', msg)[0])) # Perceptual.
+                    int(re.findall(r'^.*\s(\d+)\%', msg)[0])) # Perceptual.
                 wx.CallAfter(frame.m_staticText_progressInfo.SetLabel,
-                    re.findall('\|+?\s(.*)$', msg)[0]) # Eta.
+                    re.findall(r'\|+?\s(.*)$', msg)[0]) # Eta.
             except:
                 sys.__stderr__.write(msg)
         def flush(self):

--- a/kicost/spreadsheet.py
+++ b/kicost/spreadsheet.py
@@ -93,7 +93,7 @@ def create_spreadsheet(parts, prj_info, spreadsheet_filename, currency=DEFAULT_C
         # worksheet name since the variant might be a regular expression.
         # Fix the maximum worksheet name, priorize the variant string cutting
         # the board project.
-        variant = re.sub('[\[\]\\\/\|\?\*\:\(\)]','_',
+        variant = re.sub(r'[\[\]\\\/\|\?\*\:\(\)]','_',
                             variant[:(MAX_LEN_WORKSHEET_NAME)])
         WORKSHEET_NAME += '.'
         WORKSHEET_NAME = WORKSHEET_NAME[:(MAX_LEN_WORKSHEET_NAME-len(variant))]
@@ -536,7 +536,7 @@ Yellow -> Parts available, but haven't purchased enough.''',
                 else:
                     if field_name=='footprint':
                         ##TODO add future dependence of "electro-grammar" (https://github.com/kitspace/electro-grammar)
-                        field_value_footprint = re.findall('\:(.*)', part.fields[field_name])
+                        field_value_footprint = re.findall(r'\:(.*)', part.fields[field_name])
                         if field_value_footprint:
                             field_value = field_value_footprint[0]
                     else:
@@ -1223,7 +1223,7 @@ Orange -> Too little quantity available.'''
                             )
                         )
         '''
-        order_info_func_model = re.sub('[\s\n]', '', order_info_func_model) # Strip all the whitespace from the function string.
+        order_info_func_model = re.sub(r'[\s\n]', '', order_info_func_model) # Strip all the whitespace from the function string.
 
         # Create the line order by the fields specified by each distributor.
         delimier = ',"' + distributor_dict[dist]['order']['delimiter'] + '",' # Function delimiter plus distributor code delimiter.


### PR DESCRIPTION
Regular expressions containing invalid escape sequences should avoid
the normal escape sequence replacement using raw strings (r'...')

The replacement for regex is quite different from the usually used.