### PR TITLE
Keep the components sorting

### DIFF
--- a/kicost/edas/eda_kicad.py
+++ b/kicost/edas/eda_kicad.py
@@ -25,6 +25,7 @@ import sys, os, time
 from datetime import datetime
 import re
 from bs4 import BeautifulSoup
+from collections import OrderedDict
 from ..global_vars import logger, DEBUG_OVERVIEW, DEBUG_DETAILED, DEBUG_OBSESSIVE
 from ..global_vars import SEPRTR
 from ..distributors.global_vars import distributor_dict
@@ -170,7 +171,7 @@ def get_part_groups(in_file, ignore_fields, variant):
     # them with global values from the libraries and local values
     # from the schematic.
     logger.log(DEBUG_OVERVIEW, 'Getting components...')
-    components = {}
+    components = OrderedDict()
     for c in root.find('components').find_all('comp'):
 
         # Find the library used for this component.

--- a/kicost/edas/tools.py
+++ b/kicost/edas/tools.py
@@ -212,7 +212,7 @@ def group_parts(components, fields_merge):
     # First, get groups of identical components but ignore any manufacturer's
     # part numbers that may be assigned. Just collect those in a list for each group.
     logger.log(DEBUG_OVERVIEW, 'Getting groups of identical components...')
-    component_groups = {}
+    component_groups = OrderedDict()
     for ref, fields in list(components.items()): # part references and field values.
 
         # Take the field keys and values of each part and create a hash.
@@ -389,7 +389,7 @@ def remove_dnp_parts(components, variant):
 
     logger.log(DEBUG_OVERVIEW, '# Removing do not populate parts...')
 
-    accepted_components = {}
+    accepted_components = OrderedDict()
     for ref, fields in components.items():
         # Remove DNPs.
         dnp = fields.get('local:dnp', fields.get('dnp', 0))
@@ -418,7 +418,7 @@ def remove_dnp_parts(components, variant):
 
         # The part was not removed, so add it to the list of accepted components.
         accepted_components[ref] = fields
-    
+
     return accepted_components
 
 
@@ -492,7 +492,7 @@ def subpartqty_split(components):
     FIELDS_MANF = [d+'#' for d in distributor_dict]
     FIELDS_MANF.append('manf#')
 
-    split_components = {}
+    split_components = OrderedDict()
     for part_ref, part in components.items():
         try:
             # Divide the subparts in different parts keeping the other fields
@@ -792,7 +792,7 @@ def order_refs(refs, collapse=True):
 
         return num_ranges
 
-    prefix_nums = {}  # Contains a list of numbers for each distinct prefix.
+    prefix_nums = OrderedDict()  # Contains a list of numbers for each distinct prefix.
     for ref in refs:
         # Partition each part reference into its beginning part prefix and ending number.
         match = re.search(PART_REF_REGEX, ref)

--- a/kicost/kicost.py
+++ b/kicost/kicost.py
@@ -43,6 +43,7 @@ from __future__ import print_function
 import sys, os
 import pprint
 import tqdm
+from collections import OrderedDict
 
 # Stops UnicodeDecodeError exceptions.
 try:
@@ -157,7 +158,7 @@ def kicost(in_file, eda_name, out_filename,
         eda_name = [eda_name[0]] * len(in_file) #Assume the first as default.
 
     # Get groups of identical parts.
-    parts = dict()
+    parts = OrderedDict()
     prj_info = list()
     for i_prj in range(len(in_file)):
         eda_module = eda_modules[eda_name[i_prj]]


### PR DESCRIPTION
This patch makes the components sorting consistent across Python
versions. In particular for tests that check the generated file
is exactly the same.