### PR TITLE
Replace Travis CI/CD tests using GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,49 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.5', '3.7', '3.9']
+    name: Python test for ${{ matrix.python-version }}
+        
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }} 
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest xlsx2csv
+        sed -i 's/^wxPython/#wxPython/' requirements.txt 
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pip install .
+        pytest
+    - name: Store results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: Test_Output_${{ matrix.python-version }}
+        path: tests
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 KiCost
 ======
 
-[![image](https://img.shields.io/travis/xesscorp/kicost.svg)](https://travis-ci.org/xesscorp/kicost)
+[![image](https://img.shields.io/github/workflow/status/xesscorp/KiCost/Python%20application)](https://github.com/xesscorp/KiCost/actions)
 [![image](https://img.shields.io/pypi/v/kicost.svg)](https://pypi.python.org/pypi/kicost)
 
 KiCost is intended to be run as a script for generating part-cost

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 KiCost
 ===============================
 
-.. image:: https://travis-ci.com/xesscorp/KiCost.svg?branch=master
-        :target: https://travis-ci.com/xesscorp/kicost
+.. image:: https://img.shields.io/github/workflow/status/xesscorp/KiCost/Python%20application
+        :target: https://github.com/xesscorp/KiCost/actions
 
 .. image:: https://img.shields.io/pypi/v/kicost.svg
         :target: https://pypi.python.org/pypi/kicost

--- a/tests/test_kicost.py
+++ b/tests/test_kicost.py
@@ -9,8 +9,50 @@ Tests for `kicost` module.
 """
 
 import unittest
+import subprocess
+import logging
+import glob
+import os
 
 from kicost import kicost
+
+
+def do_test_single(pattern):
+    os.chdir('tests')
+    fail = False
+    if not os.path.isdir('result_test'):
+        os.mkdir('result_test')
+    if not os.path.isdir('log_test'):
+        os.mkdir('log_test')
+    try:
+        for f in glob.glob(pattern):
+            try:
+                cmd = ['./test_single.sh', '--no_price', f]
+                logging.debug('Running '+str(cmd))
+                res = subprocess.check_output(['./test_single.sh', '--no_price', f], stderr=subprocess.STDOUT)
+                logging.info(f + ' OK')
+            except subprocess.CalledProcessError as e:
+                logging.error('Failed test: '+f)
+                if e.output:
+                    logging.error('Output from command: ' + e.output.decode())
+                logfile = os.path.join('log_test', f + '.log')
+                # if os.path.isfile(logfile):
+                #     with open(logfile, 'rt') as f:
+                #         msg = f.read()
+                #     logging.error('Logfile: ' + msg)
+                fail = True
+                pass
+    finally:
+        os.chdir('..')
+    return fail
+
+
+def test_xmls():
+    assert not do_test_single('*.xml')
+
+
+def test_csvs():
+    assert not do_test_single('*.csv')
 
 
 class TestKicost(unittest.TestCase):


### PR DESCRIPTION
- Integrates the `tests/test*.sh` tests with PyTest
- Uses GitHub instead of Travis
- Tests against Python 2.7, 3.5, 3.7 and 3.9 (all passing)
- Changes the badge in README.*

Fixes #442 