### PR TITLE
Exclude libs from flake8 checks and fixed dummy-web-server.py for flake

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 159
 max-complexity = 50
-exclude = tests/dummy-web-server.py
+exclude = lib

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean-test:
 	-rm -fr htmlcov/
 
 lint:
-	flake8
+	flake8 --exclude lib
 
 test: lint
 	$(PYTEST)

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,16 @@ clean-test:
 	-rm -f .coverage
 	-rm -fr htmlcov/
 
+
+#
+# lint
+#  Check the coding style of this project
+#  Note: `flake8` configurations are set in `.flake8`
+#
+.PHONY: lint
 lint:
-	flake8 --exclude lib
+	flake8
+
 
 test: lint
 	$(PYTEST)

--- a/tests/dummy-web-server.py
+++ b/tests/dummy-web-server.py
@@ -25,20 +25,20 @@ This code is available for use under the MIT license.
 
 Copyright 2021 Brad Montgomery
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the 'Software'), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
-OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.    
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
 import argparse
@@ -72,8 +72,8 @@ class S(BaseHTTPRequestHandler):
         self._set_headers()
 
     def do_POST(self):
-        content_length = int(self.headers['Content-Length']) # <--- Gets the size of data
-        post_data = self.rfile.read(content_length).decode('utf8') # <--- Gets the data itself
+        content_length = int(self.headers['Content-Length'])  # <--- Gets the size of data
+        post_data = self.rfile.read(content_length).decode('utf8')  # <--- Gets the data itself
         self._set_headers()
         if post_data in queries:
             self.wfile.write(queries[post_data].encode("utf8"))


### PR DESCRIPTION
I started checking with flake8, ran into some issues:
- No longer checking libraries;
- Fixed messages for the dummy web server.