### PR TITLE
Run from repo

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,30 @@ jobs:
     - name: Test with pytest
       run: |
         pip install .
+        echo "* Python 3 version"
+        /usr/bin/python3 --version
+        echo "* Python version"
+        python --version
+        echo "* pip install destination"
+        which kicost
+        echo "* pip generated entry point"
+        cat `which kicost`
+        echo "* pip installed KiCost"
+        kicost --info
+        echo "* Python local installation"
+        ls -la $pythonLocation
+        echo "* Environment"
+        export
+        echo "* Patching src/kicost"
+        echo "#!"$pythonLocation/python > src/kicost.new
+        tail -n +2 src/kicost >> src/kicost.new
+        mv src/kicost.new src/kicost
+        chmod +x src/kicost
+        echo "* Patched src/kicost"
+        cat src/kicost
+        echo "* Patched src/kicost info"
+        src/kicost --info
+        echo "* Running tests"
         pytest
     - name: Store results
       if: ${{ always() }}

--- a/kicost/distributors/__init__.py
+++ b/kicost/distributors/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Júnior

--- a/kicost/distributors/api_octopart.py
+++ b/kicost/distributors/api_octopart.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Max Maisel / Hildo Guillardi Júnior

--- a/kicost/distributors/dist_local_template.py
+++ b/kicost/distributors/dist_local_template.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Junior / Max Maisel

--- a/kicost/edas/__init__.py
+++ b/kicost/edas/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo G Jr

--- a/kicost/edas/eda.py
+++ b/kicost/edas/eda.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2020 by Hildo Guillardi Junior

--- a/kicost/edas/eda_altium.py
+++ b/kicost/edas/eda_altium.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Júnior

--- a/kicost/edas/eda_kicad.py
+++ b/kicost/edas/eda_kicad.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Junior

--- a/kicost/edas/generic_csv.py
+++ b/kicost/edas/generic_csv.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Júnior

--- a/kicost/edas/tools.py
+++ b/kicost/edas/tools.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by XESS Corporation / Hildo Guillardi Júnior

--- a/kicost/kicad_config.py
+++ b/kicost/kicad_config.py
@@ -1,5 +1,5 @@
-#!python
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by Hildo Guillardi Júnior

--- a/kicost/kicost_config.py
+++ b/kicost/kicost_config.py
@@ -1,5 +1,6 @@
-#!python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by Hildo Guillardi Júnior

--- a/kicost/kicost_kicadplugin.py
+++ b/kicost/kicost_kicadplugin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by Hildo Guillardi Junior

--- a/kicost/os_windows.py
+++ b/kicost/os_windows.py
@@ -1,5 +1,5 @@
-#!python
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2018 by Hildo Guillardi Júnior

--- a/kicost/sexpdata.py
+++ b/kicost/sexpdata.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # [[[cog import cog; cog.outl('"""\n%s\n"""' % file('README.rst').read()) ]]]
 """
 S-expression parser for Python

--- a/kicost/spreadsheet.py
+++ b/kicost/spreadsheet.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # MIT license
 #
 # Copyright (C) 2019 by XESS Corporation / Hildo Guillardi Júnior

--- a/src/kicost
+++ b/src/kicost
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Salvador E. Tropea
+# Copyright (c) 2021 Instituto Nacional de Tecnología Industrial
+# License: MIT
+# Project: KiCost
+"""
+ KiCost
+
+ Wrapper to run KiCost from git repo
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from kicost.__main__ import main
+main()

--- a/tests/test_kicost.py
+++ b/tests/test_kicost.py
@@ -293,7 +293,7 @@ def run_test(name, inputs, output, extra=None, price=True, ret_err=0):
         fe = open(TESTDIR + '/log_test/0server_stderr.log', 'at')
         server = subprocess.Popen(TESTDIR + '/dummy-web-server.py', stdout=fo, stderr=fe)
     # Run KiCost
-    cmd = ['kicost', '--debug', '10']
+    cmd = ['src/kicost', '--debug', '10']
     if not price:
         cmd.append('--no_price')
     if extra:


### PR DESCRIPTION
- This patch avoids the need to run `pip install -U .`. This is intended for developers, not regular users.
- You just need to run `src/kicost` and you'll get the KiCost from the repo, not matters if another version is installed.
- The `pytest` tests also uses the code from the repo.
- I adjusted the GitHub pipeline to run the specific version of Python that we want to test. This needed some adjusts to the sehbang line of `src/kicost`