### PR TITLE
ui: fix progress bar on python 3.10+

### DIFF
--- a/kicost/kicost_gui.py
+++ b/kicost/kicost_gui.py
@@ -1155,7 +1155,7 @@ class ProgressGUI(object):
 
     def update(self, val):
         self.cur += val
-        wx.CallAfter(ProgressGUI.frame.m_gauge_process.SetValue, self.cur/self.total*100)  # Porcentual
+        wx.CallAfter(ProgressGUI.frame.m_gauge_process.SetValue, int(self.cur/self.total*100))  # Porcentual
         wx.CallAfter(ProgressGUI.frame.m_staticText_progressInfo.SetLabel, '{}/{}'.format(self.cur, self.total))  # Eta.
 
     def close(self):


### PR DESCRIPTION
Apparently python 3.10 no longer silently truncates floats to ints, (see https://github.com/python/cpython/issues/82180)

Current code passes a float to the wxGauge progress bar, which then prints (not) tracebacks like:

TypeError: Gauge.SetValue(): argument 1 has unexpected type 'float' Traceback (most recent call last):
  File "/usr/lib64/python3.10/site-packages/wx/core.py", line 3285, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )

At least someone is catching and ignoring the exception, so the app works, just the progress bar is broken.

It just needs to be explicitly forced to an int to make it work again

Signed-off-by: Karl Palsson <karlp@etactica.com>