### PR TITLE
Update eda_kicad.py to check for the property "dnp" for components

### DIFF
--- a/kicost/edas/eda_kicad.py
+++ b/kicost/edas/eda_kicad.py
@@ -53,6 +53,15 @@ def extract_fields(part):
             fields[name] = str(f.string) if f.string is not None else ''
     except AttributeError:
         pass  # No fields found for this part.
+
+    # Extract the property "dnp" shown as a X on the component in eeschema
+    try:
+        for prop in part.find_all('property'):
+            name = str(prop['name'])
+            if name == 'dnp':
+                fields[name] = name
+    except AttributeError:
+        pass  # no property for this part.
     return fields
 
 


### PR DESCRIPTION
In the function extract_fields, added a loop to check for the property "dnp" in components.

In KiCad 7.0, eeshema has an attribute "Do not populate" when editing a component properties. When enabled, the component will appear with an X overlaid on the component.  However, this gets added as a property in the .xml generated by kicad, not a field.

Tested on an in-house schematic. Did not manage to run the tests with tox due to missing Python interpreters.