### PR TITLE
Mouser API - Strip extra dots in price

### DIFF
--- a/kicost/distributors/api_mouser.py
+++ b/kicost/distributors/api_mouser.py
@@ -64,6 +64,9 @@ def get_number(string):
     if index is None:
         raise MouserError('Malformed price: ' + string)
     string = string.replace(',', '.')
+    dot_count = string.count('.')
+    if dot_count > 1:
+        string = string.replace('.', '', dot_count - 1)
     end = next((i for i, d in enumerate(string[index:], start=index) if not (d.isdigit() or d == '.')), None)
     if end is not None:
         return float(string[index:end])


### PR DESCRIPTION
Mouser seems to format things in with both dots and commas at least for [this part](https://www.mouser.se/ProductDetail/SparkFun/COM-16347?qs=OlC7AqGiEDlu3jqUyScDLw%3D%3D) with SEK as currency.

`6.817,20 kr`.

This PR removes all but the last dot (`.`) once all commas has been replaced.

I believe this should fix this error:

```
 - Mouser [api] (https://api.mouser.com/)
Progress:   0%|          | 0/45 [00:00<?, ?part/s]Traceback (most recent call last):
  File "/usr/bin/kibot", line 33, in <module>
    sys.exit(load_entry_point('kibot==1.8.2', 'console_scripts', 'kibot')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kibot/__main__.py", line 555, in main
    generate_examples(args.start, args.dry, args.type)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 1294, in generate_examples
    generate_targets(c)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 1179, in generate_targets
    generate_outputs([], False, None, False, False, dont_stop=True)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 678, in generate_outputs
    _generate_outputs(targets, invert, skip_pre, cli_order, no_priority, dont_stop)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 668, in _generate_outputs
    run_output(out, dont_stop)
  File "/usr/lib/python3/dist-packages/kibot/kiplot.py", line 569, in run_output
    out.run(get_output_dir(out.dir, out))
  File "/usr/lib/python3/dist-packages/kibot/out_base.py", line 209, in run
    self.options.run(target)
  File "/usr/lib/python3/dist-packages/kibot/out_bom.py", line 963, in run
    do_bom(output, format, comps, self)
  File "/usr/lib/python3/dist-packages/kibot/bom/bom.py", line 554, in do_bom
    write_bom(file_name, ext, groups, cfg._columns, cfg)
  File "/usr/lib/python3/dist-packages/kibot/bom/bom_writer.py", line 48, in write_bom
    result = write_xlsx(filename, groups, headings, head_names, cfg)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kibot/bom/xlsx_writer.py", line 879, in write_xlsx
    kicost_colors = create_kicost_sheet(workbook, groups, image_data, fmt_title, fmt_info, fmt_subtitle, fmt_head,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kibot/bom/xlsx_writer.py", line 732, in create_kicost_sheet
    return _create_kicost_sheet(workbook, groups, image_data, fmt_title, fmt_info, fmt_subtitle, fmt_head, fmt_cols, cfg)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kibot/bom/xlsx_writer.py", line 687, in _create_kicost_sheet
    query_part_info(parts, dist_list)
  File "/usr/lib/python3/dist-packages/kicost/kicost.py", line 76, in query_part_info
    get_dist_parts_info(parts, dist_list, currency)
  File "/usr/lib/python3/dist-packages/kicost/distributors/__init__.py", line 50, in get_dist_parts_info
    distributor_class.get_dist_parts_info(parts, dist_list, currency)
  File "/usr/lib/python3/dist-packages/kicost/distributors/distributor.py", line 166, in get_dist_parts_info
    solved = api.query_part_info(parts, list(remaining), currency)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kicost/distributors/api_mouser.py", line 376, in query_part_info
    api_mouser._query_part_info(parts, distributors, currency)
  File "/usr/lib/python3/dist-packages/kicost/distributors/api_mouser.py", line 360, in _query_part_info
    dd.price_tiers = {p['Quantity']: get_number(p['Price']) for p in pb}
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kicost/distributors/api_mouser.py", line 360, in <dictcomp>
    dd.price_tiers = {p['Quantity']: get_number(p['Price']) for p in pb}
                                     ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/kicost/distributors/api_mouser.py", line 69, in get_number
    return float(string[index:end])
           ^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: could not convert string to float: '6.817.20'
Progress:  29%|██▉       | 13/45 [00:00<00:01, 23.60part/s]
```